### PR TITLE
Add Author attribution

### DIFF
--- a/doc/coinsplitter_user_guide.md
+++ b/doc/coinsplitter_user_guide.md
@@ -1,5 +1,7 @@
 # Coin Splitter User Guide
 
+Author: Mark B. Lundeberg
+
 Repository: [https://github.com/markblundeberg/coinsplitter_checkdatasig](https://github.com/markblundeberg/coinsplitter_checkdatasig)
 
 ## Description


### PR DESCRIPTION
Clarify Mark as the author of the guide, since the git commit makes it look like I was the author (which I'm not).